### PR TITLE
yolean/node-build

### DIFF
--- a/node-build/Dockerfile
+++ b/node-build/Dockerfile
@@ -1,0 +1,8 @@
+FROM yolean/node
+
+RUN runtimeDeps='make g++ python libsasl2-2 libsasl2-dev' \
+  && set -ex \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update && apt-get install -y $runtimeDeps --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/log/apt /var/log/dpkg.log /var/log/alternatives.log


### PR DESCRIPTION
```
$ docker history yolean/node-build
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
7d98d1a8c8b7        20 seconds ago      /bin/sh -c runtimeDeps='make g++ python li...   171MB               
ae30bb361aa3        13 days ago         /bin/sh -c #(nop)  CMD ["node"]                 0B                  
e5aa16928495        13 days ago         /bin/sh -c buildDeps='gnupg dirmngr curl c...   56.4MB              
d1cdbe7ad315        13 days ago         /bin/sh -c #(nop)  ENV NODE_VERSION=8.4.0       0B                  
ce41f727c0b5        13 days ago         /bin/sh -c #(nop)  ENV NPM_CONFIG_LOGLEVEL...   0B                  
586bd4996026        13 days ago         /bin/sh -c groupadd --gid 1000 node   && u...   333kB               
112097a38e03        5 weeks ago         /bin/sh -c #(nop)  CMD ["bash"]                 0B                  
<missing>           5 weeks ago         /bin/sh -c #(nop) ADD file:fa8dd9a679f473a...   55.3MB              
$ docker push yolean/node-build
The push refers to a repository [docker.io/yolean/node-build]
246632ec12fe: Pushed 
00092c4bc43d: Mounted from yolean/node 
c1b71e94128c: Mounted from yolean/node 
eb78099fbf7f: Mounted from yolean/java 
latest: digest: sha256:c87450433eca0e43ac72903c07ae6cc2eac8318e183a1003e428bbcad253cabf size: 1161
```

... so note that is saves 171 MB image to use `yolean/node` with a `buildDeps` style apt-get + cleanup wrapped around npm install.