### PR TITLE
Add image with kafkacat + nodejs

### DIFF
--- a/kafkacat-node/Dockerfile
+++ b/kafkacat-node/Dockerfile
@@ -1,7 +1,7 @@
-FROM solsson/kafkacat-fixedkey@sha256:fb27acf4c7ca25eca6a6cffe145cb492ee4d4c87cba0459787fb43f8040f6d7b \
+FROM solsson/kafkacat@sha256:2c539e4f58960ab7872976ebc664dd92de18cf27e7cbbeb296d654a2351f6ca4 \
   as kafkcat-binary
 
-FROM yolean/node@sha256:b16c9154c4e8851f2a1fc31a2da3609284ed2ad65dc15249f9ef9b49bed835fd
+FROM yolean/node@sha256:230b269710a1d09b9ebbdeeea0fc4e69ac1388ab71b0178452e817065f69c700
 
 COPY --from=kafkcat-binary /usr/local/bin/kafkacat /usr/local/bin/kafkacat
 

--- a/kafkakat-node/Dockerfile
+++ b/kafkakat-node/Dockerfile
@@ -1,6 +1,7 @@
-FROM solsson/kafkacat-fixedkey@sha256:e23753bc0900e7b95d29f8c9cb05440eb27d854f367d407ce4ab2955093ad360 as kafkcat-binary
+FROM solsson/kafkacat-fixedkey@sha256:fb27acf4c7ca25eca6a6cffe145cb492ee4d4c87cba0459787fb43f8040f6d7b \
+  as kafkcat-binary
 
-FROM yolean/node
+FROM yolean/node@sha256:b16c9154c4e8851f2a1fc31a2da3609284ed2ad65dc15249f9ef9b49bed835fd
 
 COPY --from=kafkcat-binary /usr/local/bin/kafkacat /usr/local/bin/kafkacat
 

--- a/kafkakat-node/Dockerfile
+++ b/kafkakat-node/Dockerfile
@@ -1,0 +1,13 @@
+FROM solsson/kafkacat-fixedkey@sha256:e23753bc0900e7b95d29f8c9cb05440eb27d854f367d407ce4ab2955093ad360 as kafkcat-binary
+
+FROM yolean/node
+
+COPY --from=kafkcat-binary /usr/local/bin/kafkacat /usr/local/bin/kafkacat
+
+RUN set -ex; \
+  runtimeDeps='libssl1.1 libsasl2-2'; \
+  export DEBIAN_FRONTEND=noninteractive; \
+  apt-get update && apt-get install -y $runtimeDeps --no-install-recommends; \
+  rm -rf /var/lib/apt/lists/*; \
+  rm /var/log/dpkg.log /var/log/apt/*.log; \
+  kafkacat -V


### PR DESCRIPTION
The ultimate docker image :)

Pushed as `yolean/kafkacat-node@sha256:bcec1c7bf17e72007a0905ad9eff178e81c4f77deb789bc1b60e5f7bb9037aec`.

I've just been waiting for a chance to learn the relatively new feature with multiple `FROM`s. I still had to do some copying from https://github.com/edenhill/kafkacat/blob/master/Dockerfile.

I used the kafkacat binary from https://github.com/edenhill/kafkacat/pull/123 because it can benefit from some more testing.

