### PR TITLE
Includes memdown, to get node-gyp built

### DIFF
--- a/node-kafka/Dockerfile
+++ b/node-kafka/Dockerfile
@@ -20,6 +20,8 @@ RUN set -ex; \
   \
   chown node ${NODE_PATH}; \
   su node -c "npm install -g node-rdkafka@${NODE_RDKAFKA_VERSION} snappy@${SNAPPY_VERSION} memdown@${MEMDOWN_VERSION}"; \
+  rm -rf /home/node/.npm; \
+  rm -rf /home/node/.node-gyp; \
   \
   apt-get purge -y --auto-remove $buildDeps; \
   rm -rf /var/lib/apt/lists/*; \

--- a/node-kafka/Dockerfile
+++ b/node-kafka/Dockerfile
@@ -2,7 +2,8 @@ FROM yolean/node
 
 ENV NODE_PATH=/usr/local/lib/node_modules \
   NODE_RDKAFKA_VERSION=2.2.1 \
-  SNAPPY_VERSION=5.0.5
+  SNAPPY_VERSION=5.0.5 \
+  MEMDOWN_VERSION=1.4.1
 
 RUN set -ex; \
   export DEBIAN_FRONTEND=noninteractive; \
@@ -18,7 +19,7 @@ RUN set -ex; \
   apt-get update && apt-get install -y $runDeps $buildDeps --no-install-recommends; \
   \
   chown node ${NODE_PATH}; \
-  su node -c "npm install -g node-rdkafka@${NODE_RDKAFKA_VERSION}  snappy@${SNAPPY_VERSION}"; \
+  su node -c "npm install -g node-rdkafka@${NODE_RDKAFKA_VERSION} snappy@${SNAPPY_VERSION} memdown@${MEMDOWN_VERSION}"; \
   \
   apt-get purge -y --auto-remove $buildDeps; \
   rm -rf /var/lib/apt/lists/*; \

--- a/node-kafka/Dockerfile
+++ b/node-kafka/Dockerfile
@@ -1,7 +1,7 @@
 FROM yolean/node
 
 ENV NODE_PATH=/usr/local/lib/node_modules \
-  NODE_RDKAFKA_VERSION=2.2.1 \
+  NODE_RDKAFKA_VERSION=2.2.3 \
   SNAPPY_VERSION=5.0.5 \
   MEMDOWN_VERSION=1.4.1
 

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -44,6 +44,7 @@ RUN runtimeDeps='procps' \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
   && apt-get purge -y --auto-remove $buildDeps \
+  && rm -rf /root/.gnupg \
   && npm --version \
   && rm -rf /var/log/apt /var/log/dpkg.log /var/log/alternatives.log
 


### PR DESCRIPTION
Pushed: `yolean/node-kafka:memdown-1.4.1@sha256:6e4bec5337d13fdbf7b3402a1c024e74e15d72de6470dc35d7daccd7420c5b45`
