### PR TITLE
Build node-kafka-cache image

### DIFF
--- a/node-kafka-cache/Dockerfile
+++ b/node-kafka-cache/Dockerfile
@@ -1,6 +1,6 @@
 FROM yolean/node-kafka
 
-ENV KAFKA_CACHE_VERSION=1.1.1
+ENV KAFKA_CACHE_VERSION=1.2.0
 
 RUN set -ex; \
   \

--- a/node-kafka-cache/Dockerfile
+++ b/node-kafka-cache/Dockerfile
@@ -1,0 +1,10 @@
+FROM yolean/node-kafka
+
+ENV KAFKA_CACHE_VERSION=1.1.1
+
+RUN set -ex; \
+  \
+  chown node ${NODE_PATH}; \
+  su node -c "npm install -g kafka-cache@${KAFKA_CACHE_VERSION}"; \
+  rm -rf /home/node/.npm; \
+  rm -rf /home/node/.node-gyp;


### PR DESCRIPTION
.... with our very own https://www.npmjs.com/package/kafka-cache

First shot at https://github.com/Yolean/kafka-cache/issues/9.

Fails, by design, when it tries to preinstall /usr/local/lib/node_modules/kafka-cache/node_modules/node-rdkafka. It shouldn't because we're basing the image on `node-kafka`.