### PR TITLE
ystack-runner with y1's yarn and npx

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -563,46 +563,6 @@ jobs:
       continue-on-error: false
       timeout-minutes: 45
     -
-      name: Build and push node-kafka-sqlite root
-      uses: docker/build-push-action@v6.18.0
-      env:
-        SOURCE_DATE_EPOCH: 0
-        BUILDKIT_PROGRESS: plain
-        DOCKER_BUILDKIT: 1
-      with:
-        context: node-kafka-sqlite
-        tags: |
-          ghcr.io/yolean/node-kafka-sqlite:root
-          ghcr.io/yolean/node-kafka-sqlite:${{ github.sha }}-root
-        platforms: linux/amd64,linux/arm64/v8
-        push: true
-        cache-from: type=registry,ref=ghcr.io/yolean/node-kafka-sqlite:_buildcache-root
-        cache-to: type=registry,ref=ghcr.io/yolean/node-kafka-sqlite:_buildcache-root,mode=max
-        build-contexts: |
-          yolean/node-kafka:root=docker-image://ghcr.io/yolean/node-kafka:root
-      continue-on-error: false
-      timeout-minutes: 45
-    -
-      name: Build and push node-kafka-sqlite latest
-      uses: docker/build-push-action@v6.18.0
-      env:
-        SOURCE_DATE_EPOCH: 0
-        BUILDKIT_PROGRESS: plain
-        DOCKER_BUILDKIT: 1
-      with:
-        context: to-nonroot/node-kafka-sqlite
-        tags: |
-          ghcr.io/yolean/node-kafka-sqlite:latest
-          ghcr.io/yolean/node-kafka-sqlite:${{ github.sha }}
-        platforms: linux/amd64,linux/arm64/v8
-        push: true
-        cache-from: type=registry,ref=ghcr.io/yolean/node-kafka-sqlite:_buildcache
-        cache-to: type=registry,ref=ghcr.io/yolean/node-kafka-sqlite:_buildcache,mode=max
-        build-contexts: |
-          yolean/node-kafka-sqlite:root=docker-image://ghcr.io/yolean/node-kafka-sqlite:root
-      continue-on-error: false
-      timeout-minutes: 45
-    -
       name: Build and push node-kafka-duckdb root
       uses: docker/build-push-action@v6.18.0
       env:

--- a/builder-base/Dockerfile
+++ b/builder-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM ghcr.io/yolean/ystack-runner:3481f4e5d3483a27837e533e76f1cacc35358b05@sha256:5d33478edc7e77485e6ba20a7173e34f8b8cb76fc0d2f1867a8bd64a5a7fcaf3 \
+FROM --platform=$TARGETPLATFORM ghcr.io/yolean/ystack-runner:5035755bd8ade59842c4bfefad52de071dcf36c6@sha256:591e593fd7014f866b0f6bd645ff8282bee52e2a5a41b0dda2d449162cd6698b \
   as base
 
 FROM base as nonroot
@@ -10,7 +10,6 @@ RUN set -e; \
   mkdir -p usr/local/src/ystack/bin && chown nonroot usr/local/src/ystack/bin; \
   mkdir -p home/nonroot/.cache/ystack-bin; \
   mkdir -p home/nonroot/.cache/npm; \
-  (cd usr/local/src/ystack/bin/; ln -s /usr/local/lib/node_modules/yarn/bin/yarn); \
   chown root home; chown -R nonroot:nogroup home/nonroot
 
 FROM base
@@ -22,4 +21,3 @@ ENV \
   YSTACK_BIN_DOWNLOAD_CACHE=/home/nonroot/.cache/ystack-bin \
   npm_config_update_notifier=false
 
-RUN npm install -g --ignore-scripts --no-bin-links yarn@1.22.19

--- a/duckdb/Dockerfile
+++ b/duckdb/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=$BUILDPLATFORM yolean/builder-base
 ARG TARGETARCH
-ARG DUCKDB_TAG=v1.5.0
+ARG DUCKDB_TAG=v1.5.1
 
 RUN set -ex; \
   ARCH=$TARGETARCH; \

--- a/images.sh
+++ b/images.sh
@@ -26,7 +26,6 @@ java
 node
 node-kafka
 node-kafka-cache
-node-kafka-sqlite
 node-kafka-duckdb
 node-watchexec
 node-kafka-watch

--- a/node-distroless/Dockerfile
+++ b/node-distroless/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/nodejs24-debian13:nonroot@sha256:38792f83f35f2df89d403f49491782981dd13a853bbcb09ff978d79328263463
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/nodejs24-debian13:nonroot@sha256:924918584d0e6793e578fc0e98b8b8026ae4ac2ccf2fea283bc54a7165441ccd
 
 WORKDIR /app
 CMD [ "./main.js" ]

--- a/node-kafka-duckdb/package.json
+++ b/node-kafka-duckdb/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@duckdb/node-bindings": "1.5.0-r.1",
+    "@duckdb/node-bindings": "1.5.1-r.1",
     "@google-cloud/pubsub": "5.3.0"
   }
 }

--- a/node-kafka-sqlite/Dockerfile
+++ b/node-kafka-sqlite/Dockerfile
@@ -1,5 +1,0 @@
-FROM --platform=$TARGETPLATFORM yolean/node-kafka:root
-
-COPY package.json /app/
-
-RUN npm install

--- a/node-kafka-sqlite/package.json
+++ b/node-kafka-sqlite/package.json
@@ -1,6 +1,0 @@
-{
-  "private": true,
-  "dependencies": {
-    "better-sqlite3": "12.6.2"
-  }
-}

--- a/node-kafka/Dockerfile
+++ b/node-kafka/Dockerfile
@@ -2,7 +2,6 @@ FROM --platform=$TARGETPLATFORM yolean/node:root
 
 ENV NODE_PATH=/usr/local/lib/node_modules \
   NODE_RDKAFKA_VERSION=v3.6.1 \
-  SEMVER_VERSION=7.7.3 \
   SNAPPY_VERSION=7.3.3
 
 RUN set -ex; \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM node:24.14.0-trixie-slim@sha256:4fc981bf8dfc5e36e15e0cb73c5761a14cabff0932dcad1cf26cd3c3425db5d4
+FROM --platform=$TARGETPLATFORM node:24.14.1-trixie-slim@sha256:c319bb4fac67c01ced508b67193a0397e02d37555d8f9b72958649efd302b7f8
 
 RUN runtimeDeps='procps git curl ca-certificates' \
   && set -ex \

--- a/to-nonroot/node-kafka-sqlite/Dockerfile
+++ b/to-nonroot/node-kafka-sqlite/Dockerfile
@@ -1,8 +1,0 @@
-FROM --platform=$TARGETPLATFORM yolean/node-kafka-sqlite:root
-
-# Appends the same nonroot directives as https://github.com/Yolean/kubernetes-kafka/tree/master/nonroot
-# i.e. https://github.com/solsson/dockerfiles/tree/native/kafka-nonroot
-RUN grep 'nonroot:x:65532' /etc/passwd || \
-  echo 'nonroot:x:65532:65534:nonroot:/home/nonroot:/usr/sbin/nologin' >> /etc/passwd && \
-  mkdir -p /home/nonroot && touch /home/nonroot/.bash_history && chown -R 65532:65534 /home/nonroot
-USER nonroot:nogroup


### PR DESCRIPTION
Should speed up builds, divert agents away from using npx and give us enough control over turbo task success/failure output to do reliable parsing (with duration for success and exit code for errors).

See:
- https://github.com/Yolean/y1/blob/v0.2.1/src/run.rs#L12
- https://github.com/Yolean/y1/blob/v0.2.1/src/run.rs#L14
- https://github.com/Yolean/y1/commit/3aaf8a0f6d7e09cb7b82fec483fce38ea85f101e
- https://github.com/Yolean/ystack/pull/73
- https://github.com/Yolean/kubernetes-logs-datalake/pull/5

Potentially destabilising for CI/CD but probably not for runtime.
